### PR TITLE
refactor: better `--bvids` and lint

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -27,17 +27,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest poetry
+        python -m pip install poetry ruff pytest
         # if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         poetry install
         pip install -e .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: run biliarchiver tools
+    - name: Lint with ruff
+      uses: chartboost/ruff-action@v1
+      with:
+        src: "./biliarchiver"
+    - name: Run biliarchiver tools
       run: |
         python -m biliarchiver.cli_tools.biliarchiver --help
         python -m biliarchiver.cli_tools.biliarchiver init

--- a/biliarchiver/cli_tools/down_command.py
+++ b/biliarchiver/cli_tools/down_command.py
@@ -3,7 +3,9 @@ from rich.console import Console
 
 
 @click.command(help=click.style("从哔哩哔哩下载", fg="cyan"))
-@click.option("--bvids", type=click.Path(exists=False), required=True, help="bvids 列表的文件路径")
+@click.option(
+    "--bvids", type=click.STRING, required=True, help="空白字符分隔的 bvids 列表（记得加引号），或文件路径"
+)
 @click.option(
     "--skip-ia-check",
     "-s",
@@ -26,7 +28,9 @@ from rich.console import Console
     help="最小剩余空间 (GB)，用超退出",
     show_default=True,
 )
-@click.option("--skip-to", type=int, default=0, show_default=True, help="跳过文件开头 bvid 的个数")
+@click.option(
+    "--skip-to", type=int, default=0, show_default=True, help="跳过文件开头 bvid 的个数"
+)
 def down(**kwargs):
     from biliarchiver.cli_tools.bili_archive_bvids import _down
 

--- a/biliarchiver/cli_tools/up_command.py
+++ b/biliarchiver/cli_tools/up_command.py
@@ -2,6 +2,8 @@ from io import TextIOWrapper
 import click
 import os
 
+from biliarchiver.cli_tools.utils import read_bvids
+
 
 DEFAULT_COLLECTION = "opensource_movies"
 """
@@ -15,7 +17,7 @@ BILIBILI_VIDEOS_SUB_1_COLLECTION = "bilibili_videos_sub_1"
 
 
 @click.command(help=click.style("上传至互联网档案馆", fg="cyan"))
-@click.option("--bvids", type=click.File(), default=None, help="bvids 列表的文件路径")
+@click.option("--bvids", type=click.STRING, default=None, help="bvids 列表的文件路径")
 @click.option(
     "--by-storage-home-dir",
     is_flag=True,
@@ -53,6 +55,5 @@ def up(
             upload_bvid(bvid, update_existing=update_existing, collection=collection)
 
     elif bvids:
-        bvids_from_file = bvids.read().splitlines()
-        for bvid in bvids_from_file:
+        for bvid in read_bvids(bvids):
             upload_bvid(bvid, update_existing=update_existing, collection=collection)

--- a/biliarchiver/cli_tools/utils.py
+++ b/biliarchiver/cli_tools/utils.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+from biliarchiver.utils.identifier import is_bvid
+
+
+def read_bvids(bvids: str) -> list[str]:
+    bvids_list = None
+
+    file = Path(bvids)
+    if file.exists() and file.is_file():
+        with open(file, "r", encoding="utf-8") as f:
+            bvids_list = f.read().split()
+    else:
+        bvids_list = bvids.split()
+
+    del bvids
+
+    for bvid in bvids_list:
+        assert is_bvid(bvid), f"bvid {bvid} 不合法"
+
+    assert bvids_list is not None and len(bvids_list) > 0, "bvids 为空"
+
+    return bvids_list

--- a/bilibili-archive-checker.user.js
+++ b/bilibili-archive-checker.user.js
@@ -41,7 +41,7 @@
     }
 
     function getPageNumber() {
-        return unsafeWindow.__INITIAL_STATE__?.p ?? initialState.p ?? unsafeWindow.vd?.embedPlayer?.p;
+        return unsafeWindow.__INITIAL_STATE__?.p ?? initialState?.p ?? unsafeWindow.vd?.embedPlayer?.p;
     }
 
     function humanReadableUpperPartMap(string, backward) {

--- a/poetry.lock
+++ b/poetry.lock
@@ -861,6 +861,32 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "ruff"
+version = "0.0.284"
+description = "An extremely fast Python linter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.284-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:8b949084941232e2c27f8d12c78c5a6a010927d712ecff17231ee1a8371c205b"},
+    {file = "ruff-0.0.284-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:a3930d66b35e4dc96197422381dff2a4e965e9278b5533e71ae8474ef202fab0"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d1f7096038961d8bc3b956ee69d73826843eb5b39a5fa4ee717ed473ed69c95"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bcaf85907fc905d838f46490ee15f04031927bbea44c478394b0bfdeadc27362"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3660b85a9d84162a055f1add334623ae2d8022a84dcd605d61c30a57b436c32"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0a3218458b140ea794da72b20ea09cbe13c4c1cdb7ac35e797370354628f4c05"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2fe880cff13fffd735387efbcad54ba0ff1272bceea07f86852a33ca71276f4"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d1d098ea74d0ce31478765d1f8b4fbdbba2efc532397b5c5e8e5ea0c13d7e5ae"},
+    {file = "ruff-0.0.284-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4c79ae3308e308b94635cd57a369d1e6f146d85019da2fbc63f55da183ee29b"},
+    {file = "ruff-0.0.284-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f86b2b1e7033c00de45cc176cf26778650fb8804073a0495aca2f674797becbb"},
+    {file = "ruff-0.0.284-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e37e086f4d623c05cd45a6fe5006e77a2b37d57773aad96b7802a6b8ecf9c910"},
+    {file = "ruff-0.0.284-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d29dfbe314e1131aa53df213fdfea7ee874dd96ea0dd1471093d93b59498384d"},
+    {file = "ruff-0.0.284-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:88295fd649d0aa1f1271441df75bf06266a199497afd239fd392abcfd75acd7e"},
+    {file = "ruff-0.0.284-py3-none-win32.whl", hash = "sha256:735cd62fccc577032a367c31f6a9de7c1eb4c01fa9a2e60775067f44f3fc3091"},
+    {file = "ruff-0.0.284-py3-none-win_amd64.whl", hash = "sha256:f67ed868d79fbcc61ad0fa034fe6eed2e8d438d32abce9c04b7c4c1464b2cf8e"},
+    {file = "ruff-0.0.284-py3-none-win_arm64.whl", hash = "sha256:1292cfc764eeec3cde35b3a31eae3f661d86418b5e220f5d5dba1c27a6eccbb6"},
+    {file = "ruff-0.0.284.tar.gz", hash = "sha256:ebd3cc55cd499d326aac17a331deaea29bea206e01c08862f9b5c6e93d77a491"},
+]
+
+[[package]]
 name = "schema"
 version = "0.7.5"
 description = "Simple data validation library"
@@ -947,4 +973,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e4300e1d250f776c84a8b16a34ad793d919c4f896370cdd258e33721990ed78a"
+content-hash = "eb1dfacbdf1395594885c57bab6ef5735ce4aeaa5cf8c94cf7c3f564d2dec261"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,49 @@ click-option-group = "^0.5.6"
 [tool.poetry.scripts]
 biliarchiver = "biliarchiver.cli_tools.biliarchiver:biliarchiver"
 
+[tool.poetry.group.dev.dependencies]
+ruff = "^0.0.284"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+# Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+select = ["E9", "F63", "F7", "F82"]
+ignore = []
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".direnv",
+    ".git",
+    ".git-rewrite",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".js",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+per-file-ignores = {}
+
+# Same as Black.
+line-length = 127
+
+# Assume Python 3.8
+target-version = "py39"
+
+[tool.ruff.mccabe]
+# McCabe complexity (`C901`) by default.
+# Flag errors whenever the complexity level exceeds 10.
+max-complexity = 10


### PR DESCRIPTION
- [x] Accept a list of BVIDs separated by whitespaces, both from the file and the option value.
- [x] Use the blazing fast linter that [`internetarchive` uses](https://github.com/jjjake/internetarchive/blob/ee8955065e8ffcbdc040a9d88721bb0364cfd28f/pyproject.toml#L1).