### PR TITLE
fix: 文件不存在时无法正常输出错误信息

### DIFF
--- a/biliarchiver/cli_tools/utils.py
+++ b/biliarchiver/cli_tools/utils.py
@@ -14,7 +14,7 @@ def read_bvids(bvids: str) -> list[str]:
                 bvids_list = f.read().split()
         else:
             raise Exception("Not a file")
-    except Exception as _:
+    except Exception:
         bvids_list = bvids.split()
 
     del bvids


### PR DESCRIPTION
文件不存在时，`_`（gettext）会被覆盖为 Exception，导致无法正常输出错误信息。