### PR TITLE
fix: 失败的下载任务不再导致程序提前中止

### DIFF
--- a/biliarchiver/cli_tools/bili_archive_bvids.py
+++ b/biliarchiver/cli_tools/bili_archive_bvids.py
@@ -168,11 +168,11 @@ async def _down(
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         tasks_check()
 
+    d.progress.stop()
+    print("DONE")
     if failed_tasks:
         print(f"完成所有任务，但有 {len(failed_tasks)} 个任务失败")
         raise failed_tasks[0][1]
-
-    print("DONE")
 
 
 def update_cookies_from_browser(client: AsyncClient, browser: str):

--- a/biliarchiver/cli_tools/bili_archive_bvids.py
+++ b/biliarchiver/cli_tools/bili_archive_bvids.py
@@ -169,10 +169,10 @@ async def _down(
         tasks_check()
 
     d.progress.stop()
-    print("DONE")
     if failed_tasks:
-        print(f"完成所有任务，但有 {len(failed_tasks)} 个任务失败")
-        raise failed_tasks[0][1]
+        print(_("完成所有任务，但有 {} 个任务失败").format(len(failed_tasks)))
+    else:
+        print(_("完成所有任务"))
 
 
 def update_cookies_from_browser(client: AsyncClient, browser: str):

--- a/biliarchiver/cli_tools/bili_archive_bvids.py
+++ b/biliarchiver/cli_tools/bili_archive_bvids.py
@@ -110,9 +110,9 @@ async def _down(
     d.progress.start()
     sem = asyncio.Semaphore(config.video_concurrency)
     tasks: List[asyncio.Task] = []
+    failed_tasks: list[tuple[asyncio.Task, BaseException]] = []
 
     def tasks_check():
-        failed_tasks = []
         for task in tasks:
             if task.done():
                 _task_exception = task.exception()
@@ -131,9 +131,6 @@ async def _down(
                 task.cancel()
             raise RuntimeError(s)
 
-        if failed_tasks:
-            print(f"完成所有任务，但有 {len(failed_tasks)} 个任务失败")
-            raise failed_tasks[0][1]
 
     for index, bvid in enumerate(bvids_list):
         if index < skip_to:
@@ -170,6 +167,10 @@ async def _down(
     while len(tasks) > 0:
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         tasks_check()
+
+    if failed_tasks:
+        print(f"完成所有任务，但有 {len(failed_tasks)} 个任务失败")
+        raise failed_tasks[0][1]
 
     print("DONE")
 


### PR DESCRIPTION
biliarchiver 最初的行为是：一旦有下载任务失败，程序会立即退出。`93d3635` 修改了这一行为，使得单个任务失败时，其他任务能够继续执行，并等待所有任务完成后再报错。但由于实现逻辑有误，程序还是会在有下载任务失败时立即退出。

这个 commit 修复了错误的逻辑。

Closes #34.